### PR TITLE
Change the version number of syslog-ng.conf to eliminate warning

### DIFF
--- a/install/syslog-ng.conf
+++ b/install/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.9
+@version: 3.19
 
 # Options
 options {


### PR DESCRIPTION
Issue #62 

https://forum.artixlinux.org/index.php/topic,793.0.html

No real affect, just eliminate the warning messages.  SMF worked fine now.