### PR TITLE
Add test for deleting test user

### DIFF
--- a/test/simple-mail-forwarder.bats
+++ b/test/simple-mail-forwarder.bats
@@ -161,3 +161,14 @@
     [ $ret = 0 ]
 }
 
+@test "deleting test user testi@testo.com" {
+    # Delete user
+    saslpasswd2 -d testi@testo.com
+
+    # Expect login to fail
+    output=$(nc 127.0.0.1:25 \
+        <<< 'EHLO test.com' \
+        <<< 'AUTH PLAIN dGVzdGlAdGVzdG8uY29tAHRlc3RpQHRlc3RvLmNvbQB0ZXN0' \
+        )
+    [[ $output =~ "535 5.7.8 Error: authentication failed: authentication failure" ]]
+}


### PR DESCRIPTION
Fixes #64 

Added test to remove test user and verify that it's deleted. Currently everyone who uses SMF has user `testi@testo.com` with password `test`!

Until this is merged, everyone should remove this test user manually. Run this in container:
```
saslpasswd2 -d testi@testo.com
```