### PR TITLE
Added env variable SMF_DKIM_KEYSIZE

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ It is highly advised to mount `/var/db/dkim/` folder to host, so generated keypa
 docker run -e SMF_CONFIG -p 25:25 -v $(pwd)/dkim:/var/db/dkim/ zixia/simple-mail-forwarder
 ```
 
+SMF allows using environment variables to change the size of the DKIM key:
+- `SMF_DKIM_KEYSIZE` will set the keysize of the generated DKIM key (setting `opendkim-genkey -b $SMF_DKIM_KEYSIZE`). Defaults to `2048`.
+
 Stripping sender details
 ------------------------
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -240,8 +240,11 @@ function start_postfix {
         # generates new keys only if they are not already present
         if [ ! -f /var/db/dkim/${virtualDomain}/default.private ]; then
             mkdir -p /var/db/dkim/${virtualDomain}
-            echo "OpenDKIM: Keys for ${virtualDomain} not found, generating..."
-            opendkim-genkey -b 2048 -d ${virtualDomain} -D /var/db/dkim/${virtualDomain} -s default -v
+            if [ -z "$SMF_DKIM_KEYSIZE" ]; then
+                SMF_DKIM_KEYSIZE=2048
+            fi
+            echo "OpenDKIM: Keys for ${virtualDomain} not found, generating witk keysize ${SMF_DKIM_KEYSIZE}..."
+            opendkim-genkey -b ${SMF_DKIM_KEYSIZE} -d ${virtualDomain} -D /var/db/dkim/${virtualDomain} -s default -v
         fi
 
         chmod 400 /var/db/dkim/${virtualDomain}/default.private


### PR DESCRIPTION
Environmental variable SMF_DKIM_KEYSIZE allows the user to set the keylength of the generated DKIM key (defaults to 2048)