### PR TITLE
Fix for issue where a signed cert and self signed cert can both exist

### DIFF
--- a/install/init-openssl.sh
+++ b/install/init-openssl.sh
@@ -6,36 +6,49 @@
 
 cd /etc/postfix/cert
 
-# skip generation of certificate if one exists (by mounting a volume)
-if [ ! -f "smtp.cert" ]; then
-    openssl req \
-        -new \
-        -outform PEM \
-        -nodes \
-        -keyform PEM \
-        -days 3650 \
-        -x509 \
-        -subj "/C=US/ST=Matrix/L=L/O=O/CN=${SMF_DOMAIN:-simple-mail-forwarder.com}" \
-        \
-        -newkey rsa:2048 \
-        -keyout smtp.key \
-        -out smtp.cert
-fi
+# If either certificate exists, don't generate any certificates
+if [ -f "smtp.cert" ] || [ -f "smtp.ec.cert" ]; then
+  # If RSA cert does not exist, comment out smtpd_tls_cert_file & smtpd_tls_key_file
+  if [ ! -f "smtp.cert" ]; then
+    sed -ine '/\(smtpd_tls_cert_file\|smtpd_tls_key_file\)/s/^/#/' /etc/postfix/main.cf
+  fi
 
-if [ ! -f "smtp.ec.cert" ]; then
-    openssl req \
-        -new \
-        -outform PEM \
-        -nodes \
-        -keyform PEM \
-        -days 3650 \
-        -x509 \
-        -subj "/C=US/ST=Matrix/L=L/O=O/CN=${SMF_DOMAIN:-simple-mail-forwarder.com}" \
-        \
-        -newkey ec:<(openssl ecparam -name secp384r1) \
-        -keyout smtp.ec.key \
-        -out smtp.ec.cert
-fi
+  # If EC cert does not exist, comment out smtpd_tls_eccert_file & smtpd_tls_eckey_file
+  if [ ! -f "smtp.ec.cert" ]; then
+    sed -ine '/\(smtpd_tls_eccert_file\|smtpd_tls_eckey_file\)/s/^/#/' /etc/postfix/main.cf
+  fi
 
+else
+  # skip generation of certificate if one exists (by mounting a volume)
+  if [ ! -f "smtp.cert" ]; then
+      openssl req \
+          -new \
+          -outform PEM \
+          -nodes \
+          -keyform PEM \
+          -days 3650 \
+          -x509 \
+          -subj "/C=US/ST=Matrix/L=L/O=O/CN=${SMF_DOMAIN:-simple-mail-forwarder.com}" \
+          \
+          -newkey rsa:2048 \
+          -keyout smtp.key \
+          -out smtp.cert
+  fi
+
+  if [ ! -f "smtp.ec.cert" ]; then
+      openssl req \
+          -new \
+          -outform PEM \
+          -nodes \
+          -keyform PEM \
+          -days 3650 \
+          -x509 \
+          -subj "/C=US/ST=Matrix/L=L/O=O/CN=${SMF_DOMAIN:-simple-mail-forwarder.com}" \
+          \
+          -newkey ec:<(openssl ecparam -name secp384r1) \
+          -keyout smtp.ec.key \
+          -out smtp.ec.cert
+  fi
+fi
 chown -R root.postfix /etc/postfix/cert/
 chmod -R 750 /etc/postfix/cert/


### PR DESCRIPTION
`init-openssl.sh` creates both RSA and EC self-signed certificates. When using a properly signed certificate of only one type (RSA or EC) the `init-openssl.sh` script will still generate the self-signed version of the other certificate type. This results in some requests to Postfix returning the self-signed cert rather than the signed cert.

This pull requests modifies `init-openssl.sh` to prevent the generation of self-signed certificates if either type of certificate already exists. If a certificate does exist it also checks for missing certificates and then uses sed to comment out the appropriate smtpd_tls_cert_file/key lines in main.cf.

When both or neither certificates are present it functions as it currently does.
